### PR TITLE
Implementation of a Database Pool module for multi-threaded access.

### DIFF
--- a/config/zone-server.lua.dist
+++ b/config/zone-server.lua.dist
@@ -59,6 +59,8 @@ horizon_config = {
         pass = 'horizon',
         port = 33060
     },
+
+	database_threads = 5,
     
     ------------------------------------------------------------------------------------------------------
     -- Maximum timeout of a connected session.

--- a/src/Core/Database/CMakeLists.txt
+++ b/src/Core/Database/CMakeLists.txt
@@ -8,8 +8,8 @@
 ###################################################
 # This file is part of Horizon (c).
 #
-# Copyright (c) 2019 Sagun K. (sagunxp@gmail.com).
-# Copyright (c) 2019 Horizon Dev Team.
+# Copyright (c) 2023 Sagun K. (sagunxp@gmail.com).
+# Copyright (c) 2023 Horizon Dev Team.
 #
 # Base Author - Sagun K. (sagunxp@gmail.com)
 #
@@ -27,13 +27,9 @@
 # along with this library.  If not, see <http://www.gnu.org/licenses/>.
 ###################################################
 
-add_subdirectory(Database)
-add_subdirectory(Structures)
+CollectSourceFiles(
+    ${CMAKE_CURRENT_SOURCE_DIR}
+	PRIVATE_SOURCES
+)
 
-set(DIR ${CMAKE_CURRENT_SOURCE_DIR})
-
-set(CORE_SOURCES
-    ${DIR}/Logging/Logger.cpp
-    ${DIR}/Logging/Logger.hpp
-    ${STRUCTURE_SOURCES}
-    PARENT_SCOPE)
+set(DATABASE_SOURCES ${PRIVATE_SOURCES} PARENT_SCOPE)

--- a/src/Core/Database/ConnectionPool.hpp
+++ b/src/Core/Database/ConnectionPool.hpp
@@ -1,0 +1,101 @@
+/***************************************************
+ *       _   _            _                        *
+ *      | | | |          (_)                       *
+ *      | |_| | ___  _ __ _ _______  _ __          *
+ *      |  _  |/ _ \| '__| |_  / _ \| '_  \        *
+ *      | | | | (_) | |  | |/ / (_) | | | |        *
+ *      \_| |_/\___/|_|  |_/___\___/|_| |_|        *
+ ***************************************************
+ * This file is part of Horizon (c).
+ * Copyright (c) 2023 Sagun K. (sagunxp@gmail.com).
+ * Copyright (c) 2023 Horizon Dev Team.
+ *
+ * Base Author - Sagun K. (sagunxp@gmail.com)
+ *
+ * This library is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ **************************************************/ 
+#ifndef CONNECTION_POOL_H
+#define CONNECTION_POOL_H
+
+#include <queue>
+#include <mutex>
+#include <condition_variable>
+#include <mysqlx/xdevapi.h>
+
+#include "Core/Logging/Logger.hpp"
+
+class ConnectionPool {
+public:
+    ConnectionPool(const std::string& host, int port, const std::string& user, const std::string& password, const std::string& schema, int pool_size)
+        : _host(host), _port(port), _user(user), _password(password), _schema(schema), _pool_size(pool_size) {
+        _initialized = true;
+        initialize_pool();
+    }
+
+    mysqlx::Session get_connection() {
+        std::unique_lock<std::mutex> lock(_mutex);
+
+        // Wait for a connection to become available
+        while (_connections.empty()) {
+            _condition.wait(lock);
+        }
+
+        // Get the next available connection
+        mysqlx::Session connection = std::move(_connections.front());
+        _connections.pop();
+
+        return connection;
+    }
+
+    void release_connection(mysqlx::Session connection) {
+        std::lock_guard<std::mutex> lock(_mutex);
+
+        // Release the connection back to the pool
+        _connections.push(std::move(connection));
+
+        // Notify a waiting thread that a connection is available
+        _condition.notify_one();
+    }
+
+private:
+    std::string _host;
+    int _port;
+    std::string _user;
+    std::string _password;
+    std::string _schema;
+    int _pool_size;
+    std::queue<mysqlx::Session> _connections;
+    std::mutex _mutex;
+    std::condition_variable _condition;
+    bool _initialized = false;
+
+    void create_connection() {
+        if (!_initialized) {
+            throw std::runtime_error("create_connection called before initialize_pool");
+        }
+
+        mysqlx::Session connection(_host, _port, _user, _password);
+        connection.sql("USE " + _schema).execute();
+        _connections.push(std::move(connection));
+    }
+
+    void initialize_pool() {
+        for (int i = 0; i < _pool_size; ++i) {
+            create_connection();
+        }
+		HLog(info) << "Database thread pool of " << _pool_size << " threads initialized.";
+    }
+};
+
+#endif // CONNECTION_POOL_H

--- a/src/Server/Common/Configuration/ServerConfiguration.hpp
+++ b/src/Server/Common/Configuration/ServerConfiguration.hpp
@@ -69,6 +69,9 @@ struct general_server_configuration
     const uint16_t &get_db_port() const { return _db_port; }
     void set_db_port(uint16_t port) { _db_port = port; }
 
+    const uint8_t &get_db_threads() const { return _db_threads; }
+    void set_db_threads(uint8_t threads) { _db_threads = threads; }
+
     boost::filesystem::path _config_file_path{""};
 	
     int shutdown_signal;    ///< Shutdown signal.
@@ -78,6 +81,7 @@ struct general_server_configuration
     
     std::string _db_host, _db_user, _db_pass, _db_database;
     uint16_t _db_port{3306};
+    uint8_t _db_threads{5};
     
 };
 

--- a/src/Server/Common/Server.hpp
+++ b/src/Server/Common/Server.hpp
@@ -31,6 +31,7 @@
 #define HORIZON_SERVER_HPP
 
 #include "CLI/CLICommand.hpp"
+#include "Core/Database/ConnectionPool.hpp"
 
 using boost::asio::ip::tcp;
 
@@ -87,7 +88,7 @@ public:
 	 */
 	bool clicmd_shutdown(std::string /*cmd*/);
     
-	std::shared_ptr<mysqlx::Session> get_db_connection() { return _mysql_connection; }
+	std::shared_ptr<ConnectionPool> database_pool() { return _mysql_connections; }
     
 protected:
 	/* General Configuration */
@@ -98,7 +99,7 @@ protected:
 	std::atomic<shutdown_stages> _shutdown_stage;
 	std::atomic<int> _shutdown_signal;
 	std::unordered_map<std::string, std::function<bool(std::string)>> _cli_function_map;
-	std::shared_ptr<mysqlx::Session> _mysql_connection;
+	std::shared_ptr<ConnectionPool> _mysql_connections;
     
 	/**
 	 * Core IO Service

--- a/src/Server/Zone/CMakeLists.txt
+++ b/src/Server/Zone/CMakeLists.txt
@@ -59,6 +59,7 @@ add_executable(zone
 	${GAME_SOURCES}
 	${LUA_SOURCES}
 	${INTERFACE_SOURCES}
+	${DATABASE_SOURCES}
 )
 
 target_precompile_headers(zone

--- a/src/Server/Zone/Game/Entities/Traits/Status.cpp
+++ b/src/Server/Zone/Game/Entities/Traits/Status.cpp
@@ -357,8 +357,10 @@ bool Status::initialize(std::shared_ptr<Horizon::Zone::Entities::Creature> creat
 
 bool Status::load(std::shared_ptr<Horizon::Zone::Entities::Player> pl)
 {
+	mysqlx::Session session = sZone->database_pool()->get_connection();
+	
 	try {
-		mysqlx::RowResult rr = sZone->get_db_connection()->sql("SELECT `job_id`, `strength`, `agility`, `vitality`, `intelligence`, `dexterity`, "
+		mysqlx::RowResult rr = session.sql("SELECT `job_id`, `strength`, `agility`, `vitality`, `intelligence`, `dexterity`, "
 			"`luck`, `status_points`, `skill_points`, `hp`, `sp`, `maximum_hp`, `maximum_sp`, `base_level`, `job_level`, `base_experience`, `job_experience`, "
 			"`hair_color_id`, `cloth_color_id`, `head_top_view_id`, `head_mid_view_id`, `head_bottom_view_id`, `hair_style_id`, `shield_view_id`, `weapon_view_id`, `robe_view_id`, "
 			"`body_id`, `zeny`, `virtue`, `honor`, `manner` FROM `character_status` WHERE `id` = ?")
@@ -448,6 +450,7 @@ bool Status::load(std::shared_ptr<Horizon::Zone::Entities::Player> pl)
 		set_manner(std::make_shared<Manner>(_entity, int32_t(r[30].get<int>())));
 
 		HLog(info) << "Status loaded for character " << pl->name() << "(" << pl->character()._character_id << ").";
+
 	}
 	catch (mysqlx::Error& error) {
 		HLog(error) << "Status::load:" << error.what();
@@ -457,13 +460,18 @@ bool Status::load(std::shared_ptr<Horizon::Zone::Entities::Player> pl)
 		HLog(error) << "Status::load:" << error.what();
 		return false;
 	}
+	
+	sZone->database_pool()->release_connection(std::move(session));
+	
 	return true;
 }
 
 bool Status::save(std::shared_ptr<Horizon::Zone::Entities::Player> pl)
 {
+	mysqlx::Session session = sZone->database_pool()->get_connection();
+	
 	try {
-		sZone->get_db_connection()->sql("UPDATE `character_status` SET `job_id` = ?, `base_level` = ?, `job_level` = ?, `base_experience` = ?, `job_experience` = ?, "
+		session.sql("UPDATE `character_status` SET `job_id` = ?, `base_level` = ?, `job_level` = ?, `base_experience` = ?, `job_experience` = ?, "
 			"`zeny` = ?, `strength` = ?, `agility` = ?, `vitality` = ?, `intelligence` = ?, `dexterity` = ?, `luck` = ?, `maximum_hp` = ?, `hp` = ?, `maximum_sp` = ?, `sp` = ?, "
 			"`status_points` = ?, `skill_points` = ?, `body_state` = ?, `virtue` = ?, `honor` = ?, `manner` = ?, `hair_style_id` = ?, `hair_color_id` = ?, `cloth_color_id` = ?, `body_id` = ?, "
 			"`weapon_view_id` = ?, `shield_view_id` = ?, `head_top_view_id` = ?, `head_mid_view_id` = ?, `head_bottom_view_id` = ?, `robe_view_id` = ? "
@@ -488,6 +496,9 @@ bool Status::save(std::shared_ptr<Horizon::Zone::Entities::Player> pl)
 		HLog(error) << "Status::save:" << error.what();
 		return false;
 	}
+	
+	sZone->database_pool()->release_connection(std::move(session));
+	
 	return true;
 }
 

--- a/src/Server/Zone/Zone.cpp
+++ b/src/Server/Zone/Zone.cpp
@@ -110,18 +110,22 @@ bool ZoneServer::read_config()
 
 void ZoneServer::verify_connected_sessions()
 {	
-	sZone->get_db_connection()->sql("DELETE FROM `session_data` WHERE `current_server` = ? AND `last_update` < ?")
+	mysqlx::Session session = sZone->database_pool()->get_connection();
+	session.sql("DELETE FROM `session_data` WHERE `current_server` = ? AND `last_update` < ?")
 		.bind("Z", std::time(nullptr) - config().session_max_timeout())
 		.execute();
 
-	mysqlx::RowResult rr = sZone->get_db_connection()->sql("SELECT COUNT(`game_account_id`) FROM `session_data` WHERE `current_server` = ?")
+	mysqlx::RowResult rr = session.sql("SELECT COUNT(`game_account_id`) FROM `session_data` WHERE `current_server` = ?")
 		.bind("Z")
 		.execute();
+		
 	mysqlx::Row r = rr.fetchOne();
 
 	int32_t count = r[0].get<int>();
 
 	HLog(info) << count << " connected session(s).";
+
+	sZone->database_pool()->release_connection(std::move(session));
 }
 
 void ZoneServer::update(uint64_t time)

--- a/src/Tests/CMakeLists.txt
+++ b/src/Tests/CMakeLists.txt
@@ -64,6 +64,9 @@ foreach(TEST_SOURCE ${TEST_SOURCES})
 			${CORE_DIR}/Logging/Logger.hpp)
 		set (ADD_LIBS -lpthread)
 	elseif (TEST_NAME STREQUAL "MySQLTest")
+		set (ADD_SOURCES
+			${CORE_DIR}/Logging/Logger.cpp
+			${CORE_DIR}/Logging/Logger.hpp)
 		set(ADD_INCLUDE_DIRS 
 			${MYSQL_INCLUDE_DIR} 
 			$<$<BOOL:${WIN32}>:${UNOFFICIAL_MYSQL_CONNECTOR_CPP_INCLUDE_DIR}>


### PR DESCRIPTION
ConnectionPool.hpp is a header file that defines a C++ class called ConnectionPool. This class provides a simple implementation of a connection pool for MySQL databases using the mysqlx library.

The ConnectionPool class has several private member variables, including the host, port, user, password, schema, pool size, a queue of connections, a mutex, a condition variable, and a boolean flag to indicate whether the pool has been initialized.

The class has several private member functions, including create_connection() and initialize_pool(). The create_connection() function creates a new MySQL connection using the mysqlx::Session class and adds it to the connection queue. The initialize_pool() function creates a fixed number of connections and adds them to the connection queue.

The class also has two public member functions, get_connection() and release_connection(). The get_connection() function retrieves a connection from the connection queue and returns it to the caller. If there are no available connections in the queue, the function waits until a connection becomes available. The release_connection() function adds a connection back to the connection queue.

Overall, the ConnectionPool class provides a simple and efficient way to manage a pool of MySQL connections in a multi-threaded environment.