### PR TITLE
Status registry

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -97,5 +97,6 @@
     },
     "cmake.useCMakePresets": "auto",
     "C_Cpp.default.configurationProvider": "ms-vscode.cmake-tools",
-    "C_Cpp.errorSquiggles": "disabled"
+    "C_Cpp.errorSquiggles": "disabled",
+    "cmake.configureOnOpen": true
 }

--- a/src/Server/Zone/Game/Entities/Battle/Combat.cpp
+++ b/src/Server/Zone/Game/Entities/Battle/Combat.cpp
@@ -384,9 +384,6 @@ void CombatRegistry::SkillResultOperation::execute() const
             notifier_config.action_type = operand->get_config().action_type;
             source->notify_nearby_players_of_skill_use(GRID_ENTITY_SKILL_USE_NOTIFY_SUCCESS_DAMAGE, notifier_config);
             HLog(debug) << "Finished skill result damage operation for skill: " << operand->get_config().skill_id << "." << std::endl;
-            if (target->type() == ENTITY_MONSTER) {
-                target->notify_nearby_players_of_movement(true);
-            }
             target->on_damage_received(source, damage->get_damage().left_damage + damage->get_damage().right_damage);
         }
                 break;

--- a/src/Server/Zone/Game/Entities/Battle/Combat.hpp
+++ b/src/Server/Zone/Game/Entities/Battle/Combat.hpp
@@ -194,7 +194,7 @@ protected:
         int get_priority() { return _priority; }
         void set_priority(int priority) { _priority = priority; }
 
-        virtual void execute() const = 0 { }
+        virtual void execute() const = 0;
 
         void operator=(const CombatOperation &operation) = delete;
 

--- a/src/Server/Zone/Game/Entities/Entity.cpp
+++ b/src/Server/Zone/Game/Entities/Entity.cpp
@@ -508,8 +508,8 @@ void Entity::use_skill_on_ground(int16_t skill_lv, int16_t skill_id, int16_t pos
 /**
  * Extremely time-sensitive, do not use for any other purpose than to check for very small calculations.
  */
-
 void Entity::update(uint64_t tick)
 {
 	combat_registry()->process_queue();
+	status()->status_registry()->process_queue();
 }

--- a/src/Server/Zone/Game/Entities/Traits/Attribute.cpp
+++ b/src/Server/Zone/Game/Entities/Traits/Attribute.cpp
@@ -29,6 +29,7 @@
 
 #include "Server/Zone/Game/Entities/Creature/Hostile/Monster.hpp"
 #include "Server/Zone/Game/Entities/Entity.hpp"
+#include "Server/Zone/Game/Entities/Traits/Status.hpp"
 #include "Server/Zone/Game/Entities/Player/Player.hpp"
 #include "Server/Zone/Game/Entities/Player/Assets/Inventory.hpp"
 #include "Server/Zone/Game/StaticDB/JobDB.hpp"
@@ -41,6 +42,26 @@
 
 using namespace Horizon::Zone;
 using namespace Horizon::Zone::Traits;
+
+
+void Attribute::add_base(int32_t val) { 
+	entity()->status()->status_registry()->add_to_base(this, val);
+}
+void Attribute::sub_base(int32_t val) { 
+	entity()->status()->status_registry()->subtract_from_base(this, std::min(_base_val, val));
+}
+void Attribute::add_equip(int32_t val) { 
+	entity()->status()->status_registry()->add_to_equip(this, val);
+}
+void Attribute::sub_equip(int32_t val) { 
+	entity()->status()->status_registry()->subtract_from_equip(this, std::min(_equip_val, val));
+}
+void Attribute::add_status(int32_t val) { 
+	entity()->status()->status_registry()->add_to_status(this, val);
+}
+void Attribute::sub_status(int32_t val) { 
+	entity()->status()->status_registry()->subtract_from_status(this, std::min(_status_val, val));
+}
 
 void Attribute::notify()
 {

--- a/src/Server/Zone/Game/Entities/Traits/Attribute.hpp
+++ b/src/Server/Zone/Game/Entities/Traits/Attribute.hpp
@@ -86,9 +86,8 @@ namespace Traits
 			_base_val = val;
 			notify();
 		}
-
-		virtual void add_base(int32_t val) { set_base(_base_val + val); }
-		virtual void sub_base(int32_t val) { set_base(_base_val - std::min(_base_val, val)); }
+		virtual void add_base(int32_t val);
+		virtual void sub_base(int32_t val);
 		virtual int32_t get_base() const { return _base_val; }
 
 		virtual void set_equip(int32_t val)
@@ -96,17 +95,17 @@ namespace Traits
 			_equip_val = val;
 			notify();
 		}
-		virtual void add_equip(int32_t val) { set_equip(_equip_val + val); }
-		virtual void sub_equip(int32_t val) { set_equip(_equip_val - std::min(_base_val, val)); }
+		virtual void add_equip(int32_t val);
+		virtual void sub_equip(int32_t val);
 		virtual int32_t get_equip() const { return _equip_val; }
 
-		virtual void set_status(int32_t str)
+		virtual void set_status(int32_t val)
 		{
-			_status_val = str;
+			_status_val = val;
 			notify();
 		}
-		virtual void add_status(int32_t val) { set_status(_status_val + val); }
-		virtual void sub_status(int32_t val) { set_status(_status_val - std::min(_base_val, val)); }
+		virtual void add_status(int32_t val);
+		virtual void sub_status(int32_t val);
 		virtual int32_t get_status() const { return _status_val; }
 
 		virtual int32_t total() const { return _base_val + _equip_val + _status_val; }

--- a/src/Server/Zone/Game/Entities/Traits/Status.hpp
+++ b/src/Server/Zone/Game/Entities/Traits/Status.hpp
@@ -58,6 +58,66 @@ namespace Traits
 class Status
 {
 public:
+	class StatusRegistry
+	{
+	public:
+        enum status_operation_type
+        {
+            STATUS_OPERATION_ADD_TO_BASE = 0,
+            STATUS_OPERATION_SUBTRACT_FROM_BASE,
+            STATUS_OPERATION_ADD_TO_EQUIP,
+            STATUS_OPERATION_SUBTRACT_FROM_EQUIP,
+            STATUS_OPERATION_ADD_TO_STATUS,
+            STATUS_OPERATION_SUBTRACT_FROM_STATUS
+        };
+
+		class StatusOperation
+		{
+		public:
+			StatusOperation(Attribute *attribute, status_operation_type type, uint16_t value)
+			: _priority(std::time(nullptr)), _attribute(attribute), _type(type), _value(value) { }
+			virtual ~StatusOperation() {}
+
+			void execute();
+
+			uint16_t get_priority() { return _priority; }
+			void set_priority(uint16_t priority) { _priority = priority; }
+
+			status_operation_type get_type() { return _type; }
+			uint16_t get_value() { return _value; }
+
+		protected:
+			Attribute *_attribute;
+			status_operation_type _type;
+			uint16_t _value;
+			uint16_t _priority;
+		};
+
+    	// Define a comparison function for the priority queue
+    	struct CompareStatusOperation {
+    	    bool operator()(StatusOperation* op1, StatusOperation* op2) {
+    	        return op1->get_priority() < op2->get_priority();
+    	    }
+    	};
+
+		StatusRegistry() { }
+		~StatusRegistry() { }
+
+		void add_to_base(Attribute *attribute, uint16_t value);
+		void subtract_from_base(Attribute *attribute, uint16_t value);
+		void add_to_equip(Attribute *attribute, uint16_t value);
+		void subtract_from_equip(Attribute *attribute, uint16_t value);
+		void add_to_status(Attribute *attribute, uint16_t value);
+		void subtract_from_status(Attribute *attribute, uint16_t value);
+
+		bool has_next_operation() { return !_status_operation_queue.empty(); }
+		StatusOperation *get_next_operation() { return _status_operation_queue.top(); }
+		void process_queue();
+
+	protected:
+    	std::priority_queue<StatusOperation *, std::vector<StatusOperation *>, CompareStatusOperation> _status_operation_queue;
+	};
+
 	Status(std::weak_ptr<Entity> entity, entity_type type);
 	~Status();
 
@@ -292,11 +352,14 @@ public:
 	std::shared_ptr<CreatureMode> creature_mode() { return _creature_mode; }
 	void set_creature_mode(std::shared_ptr<CreatureMode> m) { _creature_mode = m; }
 
+	std::shared_ptr<StatusRegistry> status_registry() { return _status_registry; }
+
 protected:
 	std::shared_ptr<Entity> entity() { return _entity.lock(); }
 	entity_type _type{ ENTITY_PLAYER };
 
 private:
+	std::shared_ptr<StatusRegistry> _status_registry{ nullptr };
 	std::weak_ptr<Entity> _entity;
 	// Attributes
 	std::shared_ptr<Strength> _str;

--- a/src/Server/Zone/LUA/Components/EntityComponent.cpp
+++ b/src/Server/Zone/LUA/Components/EntityComponent.cpp
@@ -657,6 +657,34 @@ void EntityComponent::sync_data_types(std::shared_ptr<sol::state> state)
         "get", &Horizon::Zone::Traits::SkillPoint::get_base,
         "set", &Horizon::Zone::Traits::SkillPoint::set_base
     );
+    state->new_usertype<Horizon::Zone::Traits::Zeny>("Zeny",
+        "attribute", [](std::shared_ptr<Horizon::Zone::Traits::Zeny> t) { return std::static_pointer_cast<Horizon::Zone::Traits::Attribute>(t); },
+        "add", &Horizon::Zone::Traits::Zeny::add_base,
+        "sub", &Horizon::Zone::Traits::Zeny::sub_base,
+        "get", &Horizon::Zone::Traits::Zeny::get_base,
+        "set", &Horizon::Zone::Traits::Zeny::set_base
+    );
+    state->new_usertype<Horizon::Zone::Traits::Honor>("Honor",
+        "attribute", [](std::shared_ptr<Horizon::Zone::Traits::Honor> t) { return std::static_pointer_cast<Horizon::Zone::Traits::Attribute>(t); },
+        "add", &Horizon::Zone::Traits::Honor::add_base,
+        "sub", &Horizon::Zone::Traits::Honor::sub_base,
+        "get", &Horizon::Zone::Traits::Honor::get_base,
+        "set", &Horizon::Zone::Traits::Honor::set_base
+    );
+    state->new_usertype<Horizon::Zone::Traits::Manner>("Manner",
+        "attribute", [](std::shared_ptr<Horizon::Zone::Traits::Manner> t) { return std::static_pointer_cast<Horizon::Zone::Traits::Attribute>(t); },
+        "add", &Horizon::Zone::Traits::Manner::add_base,
+        "sub", &Horizon::Zone::Traits::Manner::sub_base,
+        "get", &Horizon::Zone::Traits::Manner::get_base,
+        "set", &Horizon::Zone::Traits::Manner::set_base
+    );
+    state->new_usertype<Horizon::Zone::Traits::Virtue>("Virtue",
+        "attribute", [](std::shared_ptr<Horizon::Zone::Traits::Virtue> t) { return std::static_pointer_cast<Horizon::Zone::Traits::Attribute>(t); },
+        "add", &Horizon::Zone::Traits::Virtue::add_base,
+        "sub", &Horizon::Zone::Traits::Virtue::sub_base,
+        "get", &Horizon::Zone::Traits::Virtue::get_base,
+        "set", &Horizon::Zone::Traits::Virtue::set_base
+    );
 	state->new_usertype<Entity>("Entity",
 		"dest_coords", &Entity::dest_coords,
 		"walk_to_coordinates", &Entity::walk_to_coordinates,


### PR DESCRIPTION
The implementation of `StatusRegistry` impacts the use of queued operations as opposed to the direct manipulation of status attributes by providing a way to manage the order of operations and ensure that the final status values are calculated correctly.

When a value is added or subtracted from a status proportion, the `StatusRegistry` creates a `StatusOperation` object that represents the operation to be performed. The `StatusOperation` object contains information about the attribute being modified, the type of operation (addition or subtraction), the value to be added or subtracted, and a priority value that determines the order in which the operations are executed.

The `StatusRegistry` maintains a priority queue of `StatusOperation` objects, with the highest priority operations being executed first. This ensures that the order of operations does not affect the final result of the status proportions.

By using queued operations instead of direct manipulation of status attributes, the `StatusRegistry` ensures that the final status values are calculated correctly and that the order of operations does not affect the final result. This is important because the order of operations can affect the final result of the status values, and the use of queued operations ensures that the operations are executed in the correct order.

Additionally, the use of queued operations allows for more flexibility in managing status effects. For example, if a new status effect is applied while another status effect is already active, the `StatusRegistry` can queue the operations for both status effects and ensure that they are executed in the correct order. This allows for more complex status effects to be implemented without introducing bugs or errors.