### PR TITLE
Added `GridEntityMovementStopNotifier`, a movement stop notification

### DIFF
--- a/src/Server/Zone/Game/Entities/Battle/Combat.cpp
+++ b/src/Server/Zone/Game/Entities/Battle/Combat.cpp
@@ -330,8 +330,8 @@ void CombatRegistry::SkillExecutionOperation::execute() const
             source->notify_nearby_players_of_skill_use(grid_entity_skill_use_notification_type::GRID_ENTITY_SKILL_USE_NOTIFY_CASTTIME, notifier_config);
             
             if (source->is_walking())
-                source->stop_walking(true);
-                
+                source->stop_walking(true, true);
+
             HLog(debug) << "Casting skill: " << config.skd->name << " on target: " << target->guid() << "." << std::endl;
             source->map()->container()->getScheduler().Schedule(
 			    Milliseconds(config.cast_time), 

--- a/src/Server/Zone/Game/Entities/Entity.hpp
+++ b/src/Server/Zone/Game/Entities/Entity.hpp
@@ -109,7 +109,7 @@ public:
 
 	virtual void stop_movement() = 0;
 	
-	bool stop_walking(bool cancel = false);
+	bool stop_walking(bool cancel = false, bool notify = false);
 
 protected:
 	bool schedule_walk();
@@ -177,6 +177,7 @@ public:
 	void notify_nearby_players_of_existence(entity_viewport_notification_type notif_type);
 	void notify_nearby_players_of_spawn();
 	void notify_nearby_players_of_movement(bool new_entry = false);
+	void notify_nearby_players_of_movement_stop(MapCoords stop_coords);
 	void notify_nearby_players_of_skill_use(grid_entity_skill_use_notification_type notification_type, s_entity_skill_use_notifier_config config);
 	void notify_nearby_players_of_basic_attack(s_grid_entity_basic_attack_config config);
 

--- a/src/Server/Zone/Game/Map/Grid/Notifiers/GridNotifiers.cpp
+++ b/src/Server/Zone/Game/Map/Grid/Notifiers/GridNotifiers.cpp
@@ -677,3 +677,33 @@ template <> void GridEntityBasicAttackNotifier::Visit<Pet>(GridRefManager<Pet> &
 template <> void GridEntityBasicAttackNotifier::Visit<Monster>(GridRefManager<Monster> &m);
 template <> void GridEntityBasicAttackNotifier::Visit<Skill>(GridRefManager<Skill> &m);
 
+
+template <class T>
+void GridEntityMovementStopNotifier::notify(GridRefManager<T> &m)
+{
+    using namespace Horizon::Zone::Entities;
+
+    if (!m.get_size())
+        return;
+
+    for (typename GridRefManager<T>::iterator iter = m.begin(); iter != typename GridRefManager<T>::iterator(nullptr); ++iter) {
+        if (iter->source() == nullptr)
+            continue;
+
+        std::shared_ptr<Player> tpl = iter->source()->template downcast<Player>();
+
+        if (tpl->get_session() == nullptr || tpl->get_session()->clif() == nullptr)
+            continue;
+        
+        tpl->get_session()->clif()->notify_movement_stop(_entity_guid, _pos_x, _pos_y);
+    }
+}
+
+void GridEntityMovementStopNotifier::Visit(GridRefManager<Player> &m) { notify<Player>(m); }
+template <> void GridEntityMovementStopNotifier::Visit<NPC>(GridRefManager<NPC> &m);
+template <> void GridEntityMovementStopNotifier::Visit<Elemental>(GridRefManager<Elemental> &m);
+template <> void GridEntityMovementStopNotifier::Visit<Homunculus>(GridRefManager<Homunculus> &m);
+template <> void GridEntityMovementStopNotifier::Visit<Mercenary>(GridRefManager<Mercenary> &m);
+template <> void GridEntityMovementStopNotifier::Visit<Pet>(GridRefManager<Pet> &m);
+template <> void GridEntityMovementStopNotifier::Visit<Monster>(GridRefManager<Monster> &m);
+template <> void GridEntityMovementStopNotifier::Visit<Skill>(GridRefManager<Skill> &m);

--- a/src/Server/Zone/Game/Map/Grid/Notifiers/GridNotifiers.hpp
+++ b/src/Server/Zone/Game/Map/Grid/Notifiers/GridNotifiers.hpp
@@ -416,6 +416,24 @@ struct GridEntityBasicAttackNotifier
 	void Visit(GridRefManager<NOT_INTERESTED> &) { }
 };
 
+struct GridEntityMovementStopNotifier
+{
+	int _entity_guid{ 0 };
+	int _pos_x{ 0 }, _pos_y{ 0 };
+
+	explicit GridEntityMovementStopNotifier(int entity_guid, int pos_x, int pos_y)
+	: _entity_guid(entity_guid), _pos_x(pos_x), _pos_y(pos_y)
+	{ }
+
+	template <class T>
+	void notify(GridRefManager<T> &m);
+
+	void Visit(GridRefManager<entity_ns(Player)> &m);
+
+	template<class NOT_INTERESTED>
+	void Visit(GridRefManager<NOT_INTERESTED> &) { }
+};
+
 #undef entity_ns
 
 #endif /* HORIZON_ZONE_GAME_MAP_GRIDNOTIFIERS_HPP */


### PR DESCRIPTION
algorithm when the entity engages a target by using a skill on it. Movement will be stopped, correcting the official position of the entity to the position where the casting occured.