### PR TITLE
Fixes player initialization after being set in Session.

### DIFF
--- a/src/Server/Zone/Game/Entities/Player/Player.cpp
+++ b/src/Server/Zone/Game/Entities/Player/Player.cpp
@@ -139,6 +139,11 @@ bool Player::initialize()
 		return false;
 	}
 
+
+	// Ensure grid for entity.
+	map()->ensure_grid_for_entity(this, map_coords());
+	map()->add_user_count();
+	
 	set_initialized(true);
 	
 	return true;
@@ -250,9 +255,6 @@ bool Player::load()
 		
 		set_map(map);
 		set_map_coords(mcoords);
-
-		// Ensure grid for entity.
-		map->ensure_grid_for_entity(this, map_coords());
 	}
 	catch (mysqlx::Error& error) {
 		HLog(error) << "Player::load:" << error.what();

--- a/src/Server/Zone/Game/Entities/Player/Player.cpp
+++ b/src/Server/Zone/Game/Entities/Player/Player.cpp
@@ -245,9 +245,6 @@ bool Player::load()
 			HLog(warning) << "Player::load: Map " << r[10].get<std::string>() << " does not exist, setting to default map.";
 			map = MapMgr->get_map("prontera");
 		}
-
-		map->container()->manage_session(SESSION_ACTION_ADD, get_session());
-		map->add_user_count();
 		
 		get_session()->set_map_name(map->get_name());
 		

--- a/src/Server/Zone/Game/Map/MapContainerThread.cpp
+++ b/src/Server/Zone/Game/Map/MapContainerThread.cpp
@@ -241,7 +241,7 @@ void MapContainerThread::update(uint64_t diff)
 			continue;
 
 		if (action == SESSION_ACTION_ADD) {
-			if (session->is_initialized() && session->player() != nullptr && session->player()->is_initialized() == false) {
+			if (session && session->player() != nullptr && session->player()->is_initialized() == false) {
 				// Intialized player upon loading.
 				session->player()->initialize();
 			}

--- a/src/Server/Zone/Interface/ZoneClientInterface.cpp
+++ b/src/Server/Zone/Interface/ZoneClientInterface.cpp
@@ -104,6 +104,12 @@ bool ZoneClientInterface::login(uint32_t account_id, uint32_t char_id, uint32_t 
 	zc_ae2.deliver(pl->map_coords().x(), pl->map_coords().y(), DIR_SOUTH, pl->character()._font); // edit third argument to saved font.
 	
 	get_session()->set_player(pl);
+
+	// Add the player to the map after the player has been created and added to the session.
+	// This is done to prevent the player from being added to the map container before being added to the session.
+	// The player is initialized within the map container, so the player must be added to the session first.
+	pl->map()->container()->manage_session(SESSION_ACTION_ADD, get_session());
+	pl->map()->add_user_count();
 	
 	ClientSocktMgr->set_socket_for_removal(get_session()->get_socket());
 	

--- a/src/Server/Zone/Interface/ZoneClientInterface.cpp
+++ b/src/Server/Zone/Interface/ZoneClientInterface.cpp
@@ -109,7 +109,6 @@ bool ZoneClientInterface::login(uint32_t account_id, uint32_t char_id, uint32_t 
 	// This is done to prevent the player from being added to the map container before being added to the session.
 	// The player is initialized within the map container, so the player must be added to the session first.
 	pl->map()->container()->manage_session(SESSION_ACTION_ADD, get_session());
-	pl->map()->add_user_count();
 	
 	ClientSocktMgr->set_socket_for_removal(get_session()->get_socket());
 	

--- a/src/Server/Zone/Session/ZoneSession.cpp
+++ b/src/Server/Zone/Session/ZoneSession.cpp
@@ -142,6 +142,5 @@ void ZoneSession::update(uint32_t /*diff*/)
  */
 void ZoneSession::perform_cleanup()
 {
-	if (player() != nullptr)
-		MapMgr->manage_session_in_map(SESSION_ACTION_LOGOUT_AND_REMOVE, get_map_name(), shared_from_this());
+	MapMgr->manage_session_in_map(SESSION_ACTION_LOGOUT_AND_REMOVE, get_map_name(), shared_from_this());
 }


### PR DESCRIPTION
 Player should be initialized only after being set in session. Without being set, the player cannot be initalized in the map container thread (the player will be nullptr)