### PR TITLE
Fix monster AI rate, container update display, monster spawning.

### DIFF
--- a/src/Server/Zone/Game/Entities/Creature/Hostile/Monster.cpp
+++ b/src/Server/Zone/Game/Entities/Creature/Hostile/Monster.cpp
@@ -71,7 +71,7 @@ bool Monster::initialize()
     	[this] (TaskContext context)
     {
     	behavior_passive();
-    	context.Repeat(Milliseconds(std::rand() % MIN_RANDOM_TRAVEL_TIME + 1000));
+    	context.Repeat(Milliseconds(MOB_MIN_THINK_TIME_LAZY));
     });
 
 	return true;
@@ -98,17 +98,17 @@ void Monster::behavior_passive()
 		&& (next_walk_time() - std::time(nullptr) < 0)
 		&& !is_walking()) {
 	    try {
-			std::chrono::steady_clock::time_point start = std::chrono::steady_clock::now();
 			MapCoords move_c = map()->get_random_coordinates_in_walkable_range(map_coords().x(), map_coords().y(), 5, 7);
+			std::chrono::steady_clock::time_point start = std::chrono::steady_clock::now();
 			if (walk_to_coordinates(move_c.x(), move_c.y()) == false) {
 				//HLog(error) << "Monster (" << guid() << ") " << name() << " could not move to coordinates.";
 				return;
 			}
-			set_next_walk_time(std::time(nullptr) + std::rand() % 5 + 1);
 			std::chrono::steady_clock::time_point end = std::chrono::steady_clock::now();
 			std::chrono::microseconds duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
-			//HLog(debug) << "Monster::behavior_passive: script invocation time " << duration.count() << "us";
-			// Invocation time: ~915us
+			//HLog(debug) << "Monster::behavior_passive: behavior invocation time " << duration.count() << "us";
+			//HLog(debug) << "Monster::behavior_passive: Monster (" << guid() << ") " << name() << " is walking to (" << move_c.x() << ", " << move_c.y() << ").";
+			set_next_walk_time(std::time(nullptr) + std::rand() % (MIN_RANDOM_TRAVEL_TIME / 1000) + 1);
 	    } catch (sol::error &e) {
 	        HLog(error) << "Monster::behavior_passive: " << e.what();
 	    }

--- a/src/Server/Zone/Game/Entities/Entity.cpp
+++ b/src/Server/Zone/Game/Entities/Entity.cpp
@@ -128,8 +128,10 @@ bool Entity::schedule_walk()
 		return false;
 	}
 
+	/// ~1us
 	std::reverse(_walk_path.begin(), _walk_path.end());
 	_walk_path.erase(_walk_path.begin());
+	///
 
 	if (_walk_path.empty())
 	{
@@ -142,7 +144,7 @@ bool Entity::schedule_walk()
 	// @NOTE It is possible that at the time of begining movement, that a creature is not in the viewport of the player.
 	on_movement_begin();				 // 0us
 	notify_nearby_players_of_movement(); // 3us
-	walk();								 // ~173us
+	walk();								 // 3~6 us
 	return true;
 }
 
@@ -151,10 +153,8 @@ bool Entity::schedule_walk()
 void Entity::walk()
 {
 	// Fixes the jumping walk bug that happens when the walk is invoked while entity is already walking.
-	if (map()->container()->getScheduler().Count(get_scheduler_task_id(ENTITY_SCHEDULE_WALK)) > 0)
-	{
+	if ( type() == ENTITY_PLAYER && map()->container()->getScheduler().Count(get_scheduler_task_id(ENTITY_SCHEDULE_WALK)) > 0)
 		return;
-	}
 
 	if (status() == nullptr || status()->movement_speed() == nullptr)
 	{
@@ -201,13 +201,11 @@ void Entity::walk()
 			if (_changed_dest_pos != MapCoords(0, 0))
 			{
 				_dest_pos = _changed_dest_pos;
-				context.CancelGroup(get_scheduler_task_id(ENTITY_SCHEDULE_WALK));
 				schedule_walk();
 				return;
 			}
 			else if (_dest_pos == MapCoords(c.x(), c.y()) || _walk_path.empty())
 			{
-				context.CancelGroup(get_scheduler_task_id(ENTITY_SCHEDULE_WALK));
 				stop_walking();
 			}
 

--- a/src/Server/Zone/Game/Map/MapContainerThread.cpp
+++ b/src/Server/Zone/Game/Map/MapContainerThread.cpp
@@ -212,11 +212,16 @@ void MapContainerThread::start_internal()
 		update_count++;
 
 		int new_time = 0;
-		if ((new_time = std::time(nullptr)) - updates_per_second_timer >= 1) {
-			updates_per_second_timer = new_time;
-			average_update_per_second = update_count + (update_count <= 1 ? 0 : average_update_per_second) / update_count;
+		int diff_time = (new_time = std::time(nullptr)) - updates_per_second_timer;
+		if (diff_time >= 1) {
+			if (diff_time > 1)
+				average_update_per_second = (double) update_count / diff_time;
+			else
+				average_update_per_second = update_count + (update_count <= 1 ? 0 : average_update_per_second) / update_count;
+
         	HLog(info) << "Map Container " << (void*) this << " update rate: " << average_update_per_second << " update(s) per second.";
         	update_count = 0;
+			updates_per_second_timer = new_time;
    		}
 		
 		std::this_thread::sleep_for(std::chrono::microseconds(MAX_CORE_UPDATE_INTERVAL));

--- a/src/Server/Zone/LUA/Components/EntityComponent.cpp
+++ b/src/Server/Zone/LUA/Components/EntityComponent.cpp
@@ -493,7 +493,8 @@ void EntityComponent::sync_data_types(std::shared_ptr<sol::state> state)
         "hair_style", &Horizon::Zone::Traits::Status::hair_style,
         "body_style", &Horizon::Zone::Traits::Status::body_style,
         "status_point", &Horizon::Zone::Traits::Status::status_point,
-        "skill_point", &Horizon::Zone::Traits::Status::skill_point
+        "skill_point", &Horizon::Zone::Traits::Status::skill_point,
+		"zeny", &Horizon::Zone::Traits::Status::zeny
     );
 
 	state->new_usertype<Combat>("Combat",


### PR DESCRIPTION
- Fix monster minimum think time (AI) to MOB_MIN_THINK_TIME_LAZY (1000ms).
- Fix map container update rate when below 1 per second (now displays value in decimal)
- Fix monster spawning when monster_caching_enabled is false.